### PR TITLE
Exclude manual

### DIFF
--- a/typst.toml
+++ b/typst.toml
@@ -6,4 +6,4 @@ authors = ["Jonas Neugebauer"]
 license = "MIT"
 description = "A utility package for typst package authors"
 repository = "https://github.com/jneug/typst-tools4typst"
-exclude = ["tbump.toml"]
+exclude = ["tbump.toml", "t4t-manual.pdf", "t4t-manual.typ"]


### PR DESCRIPTION
The package is quite big because the PDF isn't excluded. We could also change it for the real released version if you want to (even without a bump since it's unobservable).